### PR TITLE
Changing the steaming bitrate from 8000 to 4000

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
     StreamingParameters stream_params;
     stream_params.codec = STREAMING_CODEC::H264;
-    stream_params.bitrate = 8000;
+    stream_params.bitrate = 4000;
     stream_params.chunk_size = 4096;
     if (argc == 2 && res_arg == 1) stream_params.port = atoi(argv[1]);
     if (argc > 2) stream_params.port = atoi(argv[2]);


### PR DESCRIPTION
To make the zed streaming have less motion blur. We adjusted a bunch of settings but this one made a noticeable difference.